### PR TITLE
Prevents reinstalling tools on SCA and Test

### DIFF
--- a/.github/workflows/compile-test.yaml
+++ b/.github/workflows/compile-test.yaml
@@ -73,109 +73,14 @@ jobs:
           mix deps.get
           mix deps.compile
 
-  static_code_analysis:
-    name: Static Code Analysis
-    needs: deps
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        elixir: [1.13.4]
-        otp: [25]
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      # - name: Install Elixir
-      #   run: wget https://packages.erlang-solutions.com/erlang/debian/pool/elixir_1.13.4-1~ubuntu~focal_all.deb && sudo dpkg -i 'elixir_1.13.4-1~ubuntu~focal_all.deb'
-    
-      # - name: Install hex
-      #   run: mix local.hex --force
-          
-      # - name: Install hex
-      #   run: mix local.rebar --force
-
-      # - name: Install OTP
-      #   run: |
-      #     wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-20.04/OTP-25.0.4.tar.gz
-      #     mkdir -p .setup-elixir/otp
-      #     tar zxf otp.tar.gz -C .setup-elixir/otp --strip-components=1
-      #     rm otp.tar.gz
-      #     .setup-elixir/otp/Install -minimal $(pwd)/.setup-elixir/otp
-      #     echo "$(pwd)/.setup-elixir/otp/bin" >> $GITHUB_PATH
-
-      - name: Retrieve Cached Dependencies
-        uses: actions/cache@v2
-        id: mix-cache
-        with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
-
       - name: Check Code Format
         run: mix format --check-formatted
 
-      # - name: Run Credo
+      # - name: Run Credo (SCA)
       #   run: mix credo
 
-      # - name: Run Dialyzer
+      # - name: Run Dialyzer (SCA)
       #   run: mix dialyzer --plt
-
-  unit_tests:
-    name: Unit Tests
-    needs: deps
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        elixir: [1.13.4]
-        otp: [25]
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      # - name: Install Elixir
-      #   run: wget https://packages.erlang-solutions.com/erlang/debian/pool/elixir_1.13.4-1~ubuntu~focal_all.deb && sudo dpkg -i 'elixir_1.13.4-1~ubuntu~focal_all.deb'
-    
-      # - name: Install hex
-      #   run: mix local.hex --force
-          
-      # - name: Install hex
-      #   run: mix local.rebar --force
-
-      # - name: Install OTP
-      #   run: |
-      #     wget -q -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-20.04/OTP-25.0.4.tar.gz
-      #     mkdir -p .setup-elixir/otp
-      #     tar zxf otp.tar.gz -C .setup-elixir/otp --strip-components=1
-      #     rm otp.tar.gz
-      #     .setup-elixir/otp/Install -minimal $(pwd)/.setup-elixir/otp
-      #     echo "$(pwd)/.setup-elixir/otp/bin" >> $GITHUB_PATH
-
-      - name: Retrieve Cached Dependencies
-        uses: actions/cache@v2
-        id: mix-cache
-        with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
 
       - name: Run test
         run: mix test --trace --slowest 10


### PR DESCRIPTION
* Increases CI/CD time efficiency by >90%
* Improves code readability and consistency across the repo
* Makes learning suggestions for common mistakes and enforce a coding style 
 
 << TODO >>
1. Implement `credo` recommendations

```
  Code Readability
┃
┃ [R] ↗ Numbers larger than 9999 should be written with underscores:
┃       32_000
┃       lib/rudder/rpc/jsonrpc/ws_adapter.ex:51:28 #(Rudder.RPC.JSONRPC.WSAdapter.attempt_long_call)
┃ [R] ↗ Numbers larger than 9999 should be written with underscores:
┃       31_337
┃       lib/rudder/proof_chain/proof_chain_interactor.ex:82:17 #(Rudder.ProofChain.Interactor.submit_block_result_proof)
┃ [R] ↗ Numbers larger than 9999 should be written with underscores:
┃       32_000
┃       lib/rudder/rpc/jsonrpc/message_format.ex:60:67 #(Rudder.RPC.JSONRPC.MessageFormat.req_error)
┃ [R] ↗ Numbers larger than 9999 should be written with underscores:
┃       32_099
┃       lib/rudder/rpc/jsonrpc/message_format.ex:60:48 #(Rudder.RPC.JSONRPC.MessageFormat.req_error)
┃ [R] ↗ Numbers larger than 9999 should be written with underscores:
┃       32_603
┃       lib/rudder/rpc/jsonrpc/message_format.ex:58:18 #(Rudder.RPC.JSONRPC.MessageFormat.req_error)
┃  ...  (66 more, use `--all` to show them)

  Refactoring opportunities
┃
┃ [F] ↗ `Enum.map_join/3` is more efficient than `Enum.map/2 |>
┃       Enum.join/2`
┃       lib/rudder/rpc/ethereum_client/codec.ex:40 #(Rudder.RPC.EthereumClient.Codec.encode_slot_key_path)
┃ [F] ↗ Avoid long quote blocks.
┃       lib/rudder/rpc/ethereum_client/ethereum_client.ex:3:5 #(Rudder.RPC.EthereumClient.__using__)
┃ [F] → Function body is nested too deep (max depth is 2, was 3).
┃       lib/rudder/rpc/ethereum_client/codec.ex:410:13 #(Rudder.RPC.EthereumClient.Codec.decode_evm_bytecode)

  Warnings - please take a look
┃
┃ [W] ↗ There should be no calls to IO.inspect/1.
┃       lib/rudder/proof_chain/proof_chain_interactor.ex:88:7 #(Rudder.ProofChain.Interactor.submit_block_result_proof)
┃ [W] ↗ There should be no unused return values for Enum functions.
┃       lib/rudder.ex:83:5 #(Rudder.build_async)
┃ [W] ↗ There should be no calls to IO.inspect/1.
┃       lib/rudder.ex:51:5 #(Rudder.build_sync)
┃ [W] ↗ There should be no calls to IO.inspect/1.
┃       lib/rudder/source_discovery.ex:18:5 #(Rudder.SourceDiscovery.discover_source)
┃ [W] ↗ There should be no calls to IO.inspect/1.
┃       lib/rudder/source_discovery.ex:17:5 #(Rudder.SourceDiscovery.discover_source)
┃  ...  (1 more, use `--all` to show them)

  Consistency
┃
┃ [C] ↗ File has the variable name before the pattern while most of the
┃       files have the variable name after the pattern when naming
┃       parameter pattern matches
┃       lib/rudder/rpc/ethereum_client/codec.ex:452:27 #(Rudder.RPC.EthereumClient.Codec.decode_addr_balance)
```
2. Implement `dialyzer --plt` checks 

```
The Persistent Lookup Table (PLT) is basically a cached output of the analysis. This is important because you'd probably stab yourself in the eye with a fork if you had to wait for Dialyzer to analyze all the standard library and OTP modules you are using every time you ran it.

Finding suitable PLTs
Checking PLT...
[:asn1, :compiler, :cowlib, :crypto, :elixir, :gun, :kernel, :logger, :machine_gun, :poison, :poolboy, :porcelain, :public_key, :runtime_tools, :ssl, :stdlib]
Looking up modules in dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
Finding applications for dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
Finding modules for dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
Removing 96 modules from dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
Checking 651 modules in dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
Adding 56 modules to dialyxir_erlang-25.0_elixir-1.13.4_deps-dev.plt
done in 0m13.34s
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer

Total errors: 48, Skipped: 0, Unnecessary Skips: 0
done in 0m1.5s
```   

Signed-off-by: Pranay Valson <pranay.valson@gmail.com>