### PR TITLE
adds fix to ensure erigon is build everytime on make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ submodules:
 
 build:
 	mkdir -p $(ERIGON_SUBMODULE)/build/bin
-	(cd $(ERIGON_SUBMODULE) && make evm-prod)
-	cp $(ERIGON_SUBMODULE)/build/bin/evm plugins/evm
+	(cd $(ERIGON_SUBMODULE) && make evm-dbg)
+	mv $(ERIGON_SUBMODULE)/build/bin/evm plugins/


### PR DESCRIPTION
changing from evm-prod to evm-dbg to get proper stacktraces or do other runtime analysis if needed.