### PR TITLE
Error handling

### DIFF
--- a/lib/rudder/block_result/block_result_uploader.ex
+++ b/lib/rudder/block_result/block_result_uploader.ex
@@ -42,8 +42,18 @@ defmodule Rudder.BlockResultUploader do
                block_result_hash,
                cid
              ) do
-          {:ok, :submitted} -> {:reply, {:ok, cid, block_result_hash}, state}
-          {:error, error} -> {:reply, {:error, error, ""}, state}
+          {:ok, :submitted} ->
+            {:reply, {:ok, cid, block_result_hash}, state}
+
+          {:error, errormsg} ->
+            Logger.error(
+              "#{block_height}:#{block_specimen_hash} proof submission error: #{errormsg}"
+            )
+
+            {:reply, {:error, errormsg, ""}, state}
+
+          {:error, :irreparable, errormsg} ->
+            {:reply, {:error, :irreparable, errormsg}, state}
         end
 
       {:error, error} ->


### PR DESCRIPTION
certain irrecoverable errors from proofchain implies that those must be fixed by the operator. Resuming processing subsequent block specimens don't make sense here, and so we need a way to stop the process if such a irrecoverable error occurs.