### PR TITLE
Update Github workflows for `develop`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     reviewers:
       - "sudeepdino008"
       - "kitti-katy"

--- a/.github/workflows/compile-format.yaml
+++ b/.github/workflows/compile-format.yaml
@@ -2,9 +2,12 @@ name: compile-format
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "main"
   pull_request:
-    branches: [ main ]
+    branches: 
+    - "main"
+    - "develop"
 
 env:
   MIX_ENV: test

--- a/.github/workflows/docker-ci-test.yaml
+++ b/.github/workflows/docker-ci-test.yaml
@@ -2,9 +2,12 @@ name: docker-ci-test
 
 on:
   push:
-    branches: [main]
+    branches:
+    - "main"
   pull_request:
-    branches: [main]
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   deploy-test:

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,9 +2,12 @@ name: hadolint
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "main"
   pull_request:
-    branches: [ main ]
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   hadolint:


### PR DESCRIPTION
* Moving towards new  development workflow with unstable feature testing and updates to `develop` (no CI/CD run on push but only on PR to `develop`)
* Post testing and results gathering creating another PR to merge `develop` to `main` with release tag candidate number
* Apply all actions on push and PR to `main` 
* Make sure all tests pass for PR develop -> main + testing is stable on `node-bsp-1` with `develop` 
* Merge develop -> main PR 
* Make stable release with `tag-release.yml` on `main` 