### PR TITLE
Codec version compatibility for `0.33`

### DIFF
--- a/priv/schemas/block-ethereum.avsc
+++ b/priv/schemas/block-ethereum.avsc
@@ -488,32 +488,35 @@
                            },
                            {
                               "name":"Withdrawals",
-                              "type":{
-                                 "type":"array",
-                                 "items":{
-                                    "name":"Withdrawals_record",
-                                    "type":"record",
-                                    "fields":[
-                                       {
-                                          "name":"index",
-                                          "type":"long"
-                                       },
-                                       {
-                                          "name":"validatorIndex",
-                                          "type":"long"
-                                       },
-                                       {
-                                          "name":"address",
-                                          "type":"string"
-                                       },
-                                       {
-                                          "name":"amount",
-                                          "type":"long"
-                                       }
-                                    ]
+                              "type":[
+                                 "null",
+                                 {
+                                    "type":"array",
+                                    "items":{
+                                       "name":"Withdrawals_record",
+                                       "type":"record",
+                                       "fields":[
+                                          {
+                                             "name":"index",
+                                             "type":"long"
+                                          },
+                                          {
+                                             "name":"validatorIndex",
+                                             "type":"long"
+                                          },
+                                          {
+                                             "name":"address",
+                                             "type":"string"
+                                          },
+                                          {
+                                             "name":"amount",
+                                             "type":"long"
+                                          }
+                                       ]
+                                    }
                                  }
-                              },
-                              "default":[]
+                              ],
+                              "default":"null"
                            }
                         ]
                      }


### PR DESCRIPTION
* Requires that default "null" fields are decoded from an encoded schema that matches it.
* Avrora library limitation of auto filling unavailable fields with default values from write side to read side