### PR TITLE
Decouple cqt-net v1.5 from Dencun upgrade

### DIFF
--- a/abi/ProofChainABI.json
+++ b/abi/ProofChainABI.json
@@ -50,6 +50,12 @@
         "internalType": "string",
         "name": "storageURL",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "submittedStake",
+        "type": "uint128"
       }
     ],
     "name": "BlockSpecimenProductionProofSubmitted",
@@ -71,25 +77,19 @@
         "type": "uint64"
       },
       {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "validatorBitMap",
-        "type": "uint256"
-      },
-      {
         "indexed": true,
         "internalType": "bytes32",
-        "name": "blockSpecimenHash",
+        "name": "blockhash",
         "type": "bytes32"
       },
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "resulthash",
+        "name": "specimenhash",
         "type": "bytes32"
       }
     ],
-    "name": "BlockSpecimenQuorum",
+    "name": "BlockSpecimenRewardAwarded",
     "type": "event"
   },
   {
@@ -227,24 +227,32 @@
         "internalType": "address",
         "name": "operator",
         "type": "address"
-      },
+      }
+    ],
+    "name": "OperatorDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
       {
         "indexed": false,
-        "internalType": "uint128",
-        "name": "validatorId",
-        "type": "uint128"
-      },
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "OperatorEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
       {
         "indexed": false,
-        "internalType": "uint128",
-        "name": "activeOperatorCount",
-        "type": "uint128"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
       }
     ],
     "name": "OperatorRemoved",
@@ -371,37 +379,11 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "newStakingManager",
+        "name": "newInterfaceAddress",
         "type": "address"
       }
     ],
-    "name": "StakingManagerChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint128",
-        "name": "validatorId",
-        "type": "uint128"
-      }
-    ],
-    "name": "ValidatorDisabled",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint128",
-        "name": "validatorId",
-        "type": "uint128"
-      }
-    ],
-    "name": "ValidatorEnabled",
+    "name": "StakingInterfaceChanged",
     "type": "event"
   },
   {
@@ -490,12 +472,58 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
         "internalType": "uint128",
-        "name": "validatorId",
+        "name": "commissionRate",
         "type": "uint128"
       }
     ],
-    "name": "disableValidator",
+    "name": "addValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "chainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "blockHeight",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "definitiveSpecimenHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "arbitrateBlockSpecimenSession",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "disableBSPOperator",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -506,9 +534,27 @@
         "internalType": "uint128",
         "name": "validatorId",
         "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
       }
     ],
-    "name": "enableValidator",
+    "name": "disableValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "enableBSPOperator",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -526,7 +572,7 @@
         "type": "uint64"
       }
     ],
-    "name": "finalizeResultSession",
+    "name": "finalizeAndRewardSpecimenSession",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -617,31 +663,12 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint128",
-        "name": "validatorId",
-        "type": "uint128"
-      }
-    ],
-    "name": "getEnabledOperatorCount",
-    "outputs": [
-      {
-        "internalType": "uint128",
-        "name": "",
-        "type": "uint128"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "getMetadata",
     "outputs": [
       {
         "internalType": "address",
-        "name": "stakingManager",
+        "name": "stakingInterface",
         "type": "address"
       },
       {
@@ -695,32 +722,13 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "specimenhash",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getURLS",
-    "outputs": [
-      {
-        "internalType": "string[]",
-        "name": "",
-        "type": "string[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "address",
         "name": "initialOwner",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "stakingManager",
+        "name": "stakingContract",
         "type": "address"
       }
     ],
@@ -738,54 +746,6 @@
       }
     ],
     "name": "isEnabled",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "chainId",
-        "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "blockHeight",
-        "type": "uint64"
-      },
-      {
-        "internalType": "address",
-        "name": "operator",
-        "type": "address"
-      }
-    ],
-    "name": "isSessionOpen",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint128",
-        "name": "validatorId",
-        "type": "uint128"
-      }
-    ],
-    "name": "isValidatorEnabled",
     "outputs": [
       {
         "internalType": "bool",
@@ -870,6 +830,19 @@
   {
     "inputs": [],
     "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newStakeAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "setBSPRequiredStake",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1025,11 +998,11 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "stakingManagerAddress",
+        "name": "stakingContractAddress",
         "type": "address"
       }
     ],
-    "name": "setStakingManagerAddress",
+    "name": "setStakingInterface",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/lib/refiner/proof_chain/block_specimen_event_listener.ex
+++ b/lib/refiner/proof_chain/block_specimen_event_listener.ex
@@ -64,8 +64,7 @@ defmodule Refiner.ProofChain.BlockSpecimenEventListener do
       {:ok, [_event_hash, chain_id_raw, block_height_raw, block_hash]} =
         Map.fetch(log_event, "topics")
 
-      [_validator_bit_map, specimen_hash_raw] =
-        Refiner.Util.extract_data(log_event, "(uint256,bytes32)")
+      [specimen_hash_raw] = Rudder.Util.extract_data(log_event, "(bytes32)")
 
       # prepare data to generate key
       specimen_hash = Base.encode16(specimen_hash_raw, case: :lower)

--- a/lib/refiner/proof_chain/block_specimen_event_listener.ex
+++ b/lib/refiner/proof_chain/block_specimen_event_listener.ex
@@ -9,8 +9,8 @@ defmodule Refiner.ProofChain.BlockSpecimenEventListener do
     {:ok, []}
   end
 
-  @bsp_submitted_event_hash "0xd79027d5232050798063d67d05f9e1545ea5b954e2334b09db548e63823fa1b1"
-  @bsp_awarded_event_hash "0x858deae9d885ee978c04934ceabf15ebe77ae274f3af6a05ecf3bd9880b08e1e"
+  @bsp_submitted_event_hash "0x57b0cb34d2ff9ed661f8b3c684aaee6cbf0bda5da02f4044205556817fa8e76c"
+  @bsp_awarded_event_hash "0xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a"
 
   @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(_) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Refiner.MixProject do
   def project do
     [
       app: :refiner,
-      version: "0.4.0",
+      version: "0.4.2",
       elixir: "~> 1.14.3",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
* Remove all modifications relevant to `refiner` incorporated for cqt-network v1.5 ethereum migration from Cancun upgrade 
* Revert these changes on  migration v1.5 release